### PR TITLE
ci: fix lint install in checks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,7 +7,7 @@ tasks:
     desc: Install project dependencies
     cmds:
       - go mod download
-      - brew install golangci-lint
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
   fmt:
     desc: Format Go code

--- a/client.go
+++ b/client.go
@@ -192,7 +192,9 @@ func (c *Client) do(ctx context.Context, method, urlPath string, body interface{
 	if err != nil {
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Read the entire response body for debugging
 	respBody, err := io.ReadAll(resp.Body)

--- a/integration_test_helpers.go
+++ b/integration_test_helpers.go
@@ -38,10 +38,7 @@ func loadIntegrationConfig(t *testing.T) *integrationTestConfig {
 	}
 
 	// Default to insecure for integration tests since many UniFi controllers use self-signed certs
-	insecure := true
-	if os.Getenv("UNIFI_INTEGRATION_SECURE") == "1" {
-		insecure = false
-	}
+	insecure := os.Getenv("UNIFI_INTEGRATION_SECURE") != "1"
 
 	return &integrationTestConfig{
 		BaseURL:  baseURL,


### PR DESCRIPTION
Fixes the base CI blocker currently causing Dependabot PR checks to fail before their changes are exercised.

Changes:
- Replace macOS-only `brew install golangci-lint` with `go install .../golangci-lint/v2` in `task deps`.
- Address the two lint findings surfaced once CI reaches `task check`.

Validation:
- `env UNIFI_INTEGRATION_TEST= task check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development dependency install step to use Go-based installation for the linter, improving setup consistency across environments.
* **Bug Fixes**
  * Simplified response cleanup to ensure network responses are closed reliably without surfacing close-time errors.
  * Adjusted integration test connection settings so secure and insecure modes are determined more directly from the environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->